### PR TITLE
dodane kontrolery dla sportObject i address, dodana obsługa błędów

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,14 @@
 			<version>2.5.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-oauth2-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-oauth2-client</artifactId>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-security</artifactId>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/sport/SportFacilities/controllers/AddressController.java
+++ b/src/main/java/com/sport/SportFacilities/controllers/AddressController.java
@@ -1,0 +1,59 @@
+package com.sport.SportFacilities.controllers;
+
+
+import com.sport.SportFacilities.models.Address;
+import com.sport.SportFacilities.services.AddressService;
+import com.sport.SportFacilities.utils.HateoasHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+//Kontroler nie potrzebny, zarządzanie adresami powinno odbywać się wewnątrz kontrollera SportObject
+//Mimo to nie usunięty bo może pojawi się koncepcja gdzie ponownie wykorzystamy te adresy
+@RestController
+@RequestMapping("/addresses")
+public class AddressController {
+
+    @Autowired
+    AddressService addressService;
+
+    @GetMapping()
+    public ResponseEntity getAllAddresses(){
+        Set<Address> addresses = addressService.getAllAddresses();
+        ResponseEntity responseEntity = addresses.isEmpty() ? ResponseEntity.notFound().build() : ResponseEntity.ok(addresses);
+        return responseEntity;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity getAddressById(@PathVariable Integer id){
+        Address address = addressService.getAddressById(id);
+        return ResponseEntity.ok(address);
+    }
+
+    @PostMapping()
+    public ResponseEntity createAddress(@RequestBody Address address){
+            Address createdAddress = addressService.createAddress(address);
+            URI uri = HateoasHelper
+                    .getUriWithPathAndParams("/{id}", createdAddress.getId());
+            return ResponseEntity.created(uri).body(createdAddress);
+    }
+
+    @PutMapping()
+    public ResponseEntity editAddress(@RequestBody Address address){
+        Address updatedAddress = addressService.editAddress(address);
+        return ResponseEntity.ok(updatedAddress);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity deleteAddress(@PathVariable Integer id){
+        Address address = addressService.getAddressById(id);
+        addressService.deleteAddress(address);
+        return ResponseEntity.ok().build();
+    }
+
+}
+

--- a/src/main/java/com/sport/SportFacilities/controllers/ExceptionController.java
+++ b/src/main/java/com/sport/SportFacilities/controllers/ExceptionController.java
@@ -1,0 +1,39 @@
+package com.sport.SportFacilities.controllers;
+
+import com.sport.SportFacilities.models.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+//Jest współdzielony pomiędzy wszystkie inne kontrolery
+@ControllerAdvice
+@RestController
+public class ExceptionController extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<Object> handleAllException(Exception ex, WebRequest request){
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .message(ex.getMessage())
+                .details(request.getDescription(false))
+                .build();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public final ResponseEntity<Object> handleNotFoundException(NoSuchElementException ex, WebRequest request){
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .message(ex.getMessage())
+                .details(request.getDescription(false))
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+}

--- a/src/main/java/com/sport/SportFacilities/controllers/SportObjectController.java
+++ b/src/main/java/com/sport/SportFacilities/controllers/SportObjectController.java
@@ -1,0 +1,59 @@
+package com.sport.SportFacilities.controllers;
+
+import com.google.common.base.Strings;
+import com.sport.SportFacilities.exceptions.SportObjectNotFoundException;
+import com.sport.SportFacilities.models.SportObject;
+import com.sport.SportFacilities.services.SportObjectService;
+import com.sport.SportFacilities.utils.HateoasHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/sport-objects")
+public class SportObjectController {
+
+    @Autowired
+    SportObjectService sportObjectService;
+
+    @GetMapping
+    public ResponseEntity getSportObjectsWithGivenCondition(@RequestParam(value = "city", required = false) String city) throws Exception {
+        Set<SportObject> sportObjects;
+        if (Strings.isNullOrEmpty(city)){
+            sportObjects = sportObjectService.getAllSportObjects();
+        } else {
+            sportObjects = sportObjectService.getAllSportObjectsByCity(city);
+        }
+        return ResponseEntity.ok(sportObjects);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity getSportObjectById(@PathVariable Integer id) {
+        SportObject sportObject = sportObjectService.getSportObjectById(id);
+        return ResponseEntity.ok(sportObject);
+    }
+
+    @PostMapping()
+    public ResponseEntity createSportObject(@RequestBody SportObject sportObject) {
+        SportObject createdSportObject = sportObjectService.createNewSportObject(sportObject);
+        URI uri = HateoasHelper.getUriWithPathAndParams("/{id}", createdSportObject.getId());
+        return ResponseEntity.created(uri).body(createdSportObject);
+    }
+
+    @PutMapping()
+    public ResponseEntity editSportObject(@RequestBody SportObject sportObject) {
+        SportObject updatedSportObject = sportObjectService.editSportObject(sportObject);
+        return ResponseEntity.ok(updatedSportObject);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity deleteSportObject(@PathVariable Integer id) {
+        SportObject sportObject = sportObjectService.getSportObjectById(id);
+        sportObjectService.deleteSportObject(sportObject);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sport/SportFacilities/controllers/SportObjectController.java
+++ b/src/main/java/com/sport/SportFacilities/controllers/SportObjectController.java
@@ -1,7 +1,6 @@
 package com.sport.SportFacilities.controllers;
 
 import com.google.common.base.Strings;
-import com.sport.SportFacilities.exceptions.SportObjectNotFoundException;
 import com.sport.SportFacilities.models.SportObject;
 import com.sport.SportFacilities.services.SportObjectService;
 import com.sport.SportFacilities.utils.HateoasHelper;
@@ -10,7 +9,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 @RestController

--- a/src/main/java/com/sport/SportFacilities/exceptions/SportObjectNotFoundException.java
+++ b/src/main/java/com/sport/SportFacilities/exceptions/SportObjectNotFoundException.java
@@ -1,11 +1,7 @@
 package com.sport.SportFacilities.exceptions;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import java.util.NoSuchElementException;
 
-@ResponseStatus(HttpStatus.NOT_FOUND)
 public class SportObjectNotFoundException extends NoSuchElementException {
 
     @Override

--- a/src/main/java/com/sport/SportFacilities/exceptions/SportObjectNotFoundException.java
+++ b/src/main/java/com/sport/SportFacilities/exceptions/SportObjectNotFoundException.java
@@ -1,0 +1,19 @@
+package com.sport.SportFacilities.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.NoSuchElementException;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class SportObjectNotFoundException extends NoSuchElementException {
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+
+    public SportObjectNotFoundException(String parameterName, String parameterValue) {
+        super("Cannot find sportObject with " + parameterName + "=" + parameterValue);
+    }
+}

--- a/src/main/java/com/sport/SportFacilities/models/Address.java
+++ b/src/main/java/com/sport/SportFacilities/models/Address.java
@@ -24,8 +24,7 @@ public class Address {
     @Getter
     private String postCode;
 
-//    @MapsId
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "address")
     private SportObject sportObject;
     
     public Address(Integer id, Address address) {

--- a/src/main/java/com/sport/SportFacilities/models/ExceptionResponse.java
+++ b/src/main/java/com/sport/SportFacilities/models/ExceptionResponse.java
@@ -1,0 +1,16 @@
+package com.sport.SportFacilities.models;
+
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class ExceptionResponse {
+    private LocalDateTime timestamp;
+    private String message;
+    private String details;
+}

--- a/src/main/java/com/sport/SportFacilities/models/SportObject.java
+++ b/src/main/java/com/sport/SportFacilities/models/SportObject.java
@@ -15,18 +15,20 @@ public class SportObject {
     @Getter
     @Setter
     private Integer id;
-    
+
+    @NonNull
+    @Getter
+    @Setter
+    private String name;
     @OneToMany(mappedBy = "sportObject", fetch = FetchType.LAZY)
     private Set<SwimmingPool> swimmingPool;
 
     @NonNull
     @Setter
     @Getter
-    @OneToOne(mappedBy = "sportObject", cascade = CascadeType.ALL,
-            optional = false,
-            orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL,
+            optional = false, orphanRemoval = true)
+    @JoinColumn(name = "address_id", referencedColumnName = "id")
     private Address address;
 
-    @NonNull
-    private String name;
 }

--- a/src/main/java/com/sport/SportFacilities/services/AddressService.java
+++ b/src/main/java/com/sport/SportFacilities/services/AddressService.java
@@ -4,10 +4,12 @@ import com.google.common.collect.Sets;
 import com.sport.SportFacilities.models.Address;
 import com.sport.SportFacilities.repositories.AddressRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+@Service
 public class AddressService {
     
     private AddressRepository addressRepository;

--- a/src/main/java/com/sport/SportFacilities/services/CustomerService.java
+++ b/src/main/java/com/sport/SportFacilities/services/CustomerService.java
@@ -4,10 +4,12 @@ import com.google.common.collect.Sets;
 import com.sport.SportFacilities.models.Customer;
 import com.sport.SportFacilities.repositories.CustomerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+@Service
 public class CustomerService {
     
     private CustomerRepository customerRepository;

--- a/src/main/java/com/sport/SportFacilities/services/InstructorService.java
+++ b/src/main/java/com/sport/SportFacilities/services/InstructorService.java
@@ -4,10 +4,12 @@ import com.google.common.collect.Sets;
 import com.sport.SportFacilities.models.Instructor;
 import com.sport.SportFacilities.repositories.InstructorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+@Service
 public class InstructorService {
     private InstructorRepository instructorRepository;
     

--- a/src/main/java/com/sport/SportFacilities/services/SportObjectService.java
+++ b/src/main/java/com/sport/SportFacilities/services/SportObjectService.java
@@ -1,11 +1,14 @@
 package com.sport.SportFacilities.services;
 
 import com.google.common.collect.Sets;
+import com.sport.SportFacilities.exceptions.SportObjectNotFoundException;
 import com.sport.SportFacilities.models.SportObject;
 import com.sport.SportFacilities.repositories.SportObjectRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.beans.Transient;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -25,15 +28,17 @@ public class SportObjectService {
     }
     
     public SportObject getSportObjectById(Integer id){
-        return sportObjectRepository.findById(id).orElseThrow(NoSuchElementException::new);
+        return sportObjectRepository.findById(id)
+                .orElseThrow(() -> new SportObjectNotFoundException("id",String.valueOf(id)));
     }
-    
+
     public Set<SportObject> getAllSportObjects(){
         return Sets.newHashSet(sportObjectRepository.findAll());
     }
-    
+
     public Set<SportObject> getAllSportObjectsByCity(String city){
-        return sportObjectRepository.findAllByCity(city).orElse(Collections.emptySet());
+        return sportObjectRepository.findAllByCity(city)
+                .orElseThrow(() -> new SportObjectNotFoundException("city",city));
     }
     
     public SportObject editSportObject(SportObject sportObject){

--- a/src/main/java/com/sport/SportFacilities/utils/HateoasHelper.java
+++ b/src/main/java/com/sport/SportFacilities/utils/HateoasHelper.java
@@ -1,0 +1,17 @@
+package com.sport.SportFacilities.utils;
+
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+import static org.springframework.web.util.UriComponentsBuilder.fromPath;
+
+public class HateoasHelper {
+
+    private HateoasHelper() {
+    }
+
+    public static URI getUriWithPathAndParams(String path, Object... params) {
+        return ServletUriComponentsBuilder.fromCurrentRequest().path(path).buildAndExpand(params).toUri();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.datasource.initialization-mode=always
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+server.error.include-stacktrace
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
Stworzyłem podstawowy kontroler dla sportObject i Address.
Zorientowałem się po czasie, że kontroler dla Address jest bez sensu bo adresy wykorzystujemy tylko dla SportObject, wiec można je tworzyć i usuwać razem ze SportObject, zamiast tworzyć oddzielny serwis.

Stworzyłem model ExceptionResponse, który odpowiada za to, w jakiej formie wyświetlane są błędy, możemy potem obgadać jego strukturę i zmienić na jakąś inną.

Żeby obsługa błędów działała poprawnie zamiast wyjątków NoSuchElementException w serwisach warto stworzyć oddzielne wyjątki. Na wzór stworzyłem klasę wyjątku SportObjectNotFoundException.
Daje to dwie rzeczy:
- możemy dodać przejrzysty message dla danego wyjątku
- poprzez rozszerzenie danej klasy wyjątku zaznaczamy, w którą metodę ExceptionControllera trafia wyjątek

Do zwracania requestów z błędami służy klasa ExceptionController.
W niej dodałem dwie metody.
Jedna do obsługi wszystkich błędów.
Druga do obsługi błędów rozszerzających klasę NoSuchElementExpetion.
Różnią się one jedynie zwracanym statusem.
I tak jak wcześniej wspomniałem zależnie od tego, jaką klasę rozszerza stworzony wyjątek, którego rzucamy w serwisach, do takiej metody on trafia.